### PR TITLE
Stop and Destroy GPSD Session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,11 @@ _testmain.go
 *.exe
 
 examples/examples
+
+# Vim Junk
+*.swp
+*.vim
+
+# Docker
+Dockerfile
+Makefile

--- a/examples/main.go
+++ b/examples/main.go
@@ -36,14 +36,14 @@ func setup() *gpsd.Session {
 
 func connectTest() {
 	gps := setup()
-	done := gps.Watch()
+	done, _ := gps.Watch()
 	<-done
 
 }
 
 func disconnectTest() {
 	gps := setup()
-	done := gps.Watch()
+	done, _ := gps.Watch()
 
 	fmt.Println("Sleeping...")
 	time.Sleep(3 * time.Second)
@@ -61,7 +61,7 @@ func restartSessionTest() {
 	gps := setup()
 
 	fmt.Println("Start Watching")
-	done := gps.Watch()
+	done, err := gps.Watch()
 	time.Sleep(3 * time.Second)
 
 	fmt.Println("Stop Watching")
@@ -69,13 +69,16 @@ func restartSessionTest() {
 	time.Sleep(6 * time.Second)
 
 	fmt.Println("Start Watching")
-	done = gps.Watch()
+	done, err = gps.Watch()
+	if err != nil {
+		fmt.Println(err)
+	}
 	time.Sleep(3 * time.Second)
 }
 
 func removeFilterTest() {
 	gps := setup()
-	done := gps.Watch()
+	done, _ := gps.Watch()
 
 	fmt.Println("Started watching")
 	time.Sleep(3 * time.Second)

--- a/examples/main.go
+++ b/examples/main.go
@@ -7,10 +7,10 @@ import (
 )
 
 func main() {
-	disconnectTest()
+	removeFilterTest()
 }
 
-func connectTest() {
+func setup() *gpsd.Session {
 	var gps *gpsd.Session
 	var err error
 
@@ -31,28 +31,18 @@ func connectTest() {
 
 	gps.AddFilter("SKY", skyfilter)
 
+	return gps
+}
+
+func connectTest() {
+	gps := setup()
 	done := gps.Watch()
 	<-done
 
 }
 
 func disconnectTest() {
-	gps, err := gpsd.Dial(gpsd.DefaultAddress)
-	if err != nil {
-		panic("uh oh.")
-	}
-
-	gps.AddFilter("TPV", func(r interface{}) {
-		tpv := r.(*gpsd.TPVReport)
-		fmt.Println("TPV", tpv.Mode, tpv.Time)
-	})
-
-	gps.AddFilter("SKY", func(r interface{}) {
-		sky := r.(*gpsd.SKYReport)
-
-		fmt.Println("SKY", len(sky.Satellites), "satellites")
-	})
-
+	gps := setup()
 	done := gps.Watch()
 
 	fmt.Println("Sleeping...")
@@ -65,4 +55,19 @@ func disconnectTest() {
 	fmt.Println("Sleeping...")
 	time.Sleep(5 * time.Second)
 	fmt.Println("Done sleeping")
+}
+
+func removeFilterTest() {
+	gps := setup()
+	done := gps.Watch()
+
+	fmt.Println("Started watching")
+	time.Sleep(3 * time.Second)
+
+	fmt.Println("Removing TPV Filter")
+	gps.RemoveFilter("TPV")
+
+	time.Sleep(8 * time.Second)
+	done <- true
+	fmt.Println("Finished.")
 }

--- a/examples/main.go
+++ b/examples/main.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	removeFilterTest()
+	restartSessionTest()
 }
 
 func setup() *gpsd.Session {
@@ -55,6 +55,22 @@ func disconnectTest() {
 	fmt.Println("Sleeping...")
 	time.Sleep(5 * time.Second)
 	fmt.Println("Done sleeping")
+}
+
+func restartSessionTest() {
+	gps := setup()
+
+	fmt.Println("Start Watching")
+	done := gps.Watch()
+	time.Sleep(3 * time.Second)
+
+	fmt.Println("Stop Watching")
+	done <- true
+	time.Sleep(3 * time.Second)
+
+	fmt.Println("Start Watching")
+	done = gps.Watch()
+	time.Sleep(3 * time.Second)
 }
 
 func removeFilterTest() {

--- a/examples/main.go
+++ b/examples/main.go
@@ -66,7 +66,7 @@ func restartSessionTest() {
 
 	fmt.Println("Stop Watching")
 	done <- true
-	time.Sleep(3 * time.Second)
+	time.Sleep(6 * time.Second)
 
 	fmt.Println("Start Watching")
 	done = gps.Watch()

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module gpsd
+
+go 1.15

--- a/gpsd.go
+++ b/gpsd.go
@@ -229,6 +229,10 @@ func (s *Session) AddFilter(class string, f Filter) {
 	s.filters[class] = f
 }
 
+func (s *Session) RemoveFilter(class string) {
+	s.filters[class] = nil
+}
+
 func (s *Session) deliverReport(class string, report interface{}) {
 	f := s.filters[class]
 	f(report)

--- a/gpsd.go
+++ b/gpsd.go
@@ -244,6 +244,7 @@ func watch(done chan bool, s *Session) {
 	for {
 		select {
 		case <-done:
+			fmt.Fprintf(s.socket, "?WATCH={\"enable\":false}")
 			return
 		default:
 			if line, err := s.reader.ReadString('\n'); err == nil {

--- a/gpsd.go
+++ b/gpsd.go
@@ -238,24 +238,29 @@ func watch(done chan bool, s *Session) {
 	// We're not using a JSON decoder because we first need to inspect
 	// the JSON string to determine it's "class"
 	for {
-		if line, err := s.reader.ReadString('\n'); err == nil {
-			var reportPeek gpsdReport
-			lineBytes := []byte(line)
-			if err = json.Unmarshal(lineBytes, &reportPeek); err == nil {
-				if s.filters[reportPeek.Class] == nil {
-					continue
-				}
+		select {
+		case <-done:
+			return
+		default:
+			if line, err := s.reader.ReadString('\n'); err == nil {
+				var reportPeek gpsdReport
+				lineBytes := []byte(line)
+				if err = json.Unmarshal(lineBytes, &reportPeek); err == nil {
+					if s.filters[reportPeek.Class] == nil {
+						continue
+					}
 
-				if report, err2 := unmarshalReport(reportPeek.Class, lineBytes); err2 == nil {
-					s.deliverReport(reportPeek.Class, report)
+					if report, err2 := unmarshalReport(reportPeek.Class, lineBytes); err2 == nil {
+						s.deliverReport(reportPeek.Class, report)
+					} else {
+						fmt.Println("JSON parsing error 2:", err)
+					}
 				} else {
-					fmt.Println("JSON parsing error 2:", err)
+					fmt.Println("JSON parsing error:", err)
 				}
 			} else {
-				fmt.Println("JSON parsing error:", err)
+				fmt.Println("Stream reader error (is gpsd running?):", err)
 			}
-		} else {
-			fmt.Println("Stream reader error (is gpsd running?):", err)
 		}
 	}
 }


### PR DESCRIPTION
It is now possible to remove a filter with the RemoveFilter function and to stop
the watch goroutine by sending a signal to the "done" channel.

You can now only add one filter per class type and public interface methods
can return errors.

- Updated gitignore
- Initialized go mod
- Session.filters is now a map with Filter values, not []Filter values
- Sending value on done channel exits watch goroutine
- Terminate goroutine test
- RemoveFilter functionality
- RemoveFilter test
- Restart session test
- Stop receiving data on socket when watch() goroutine exits
- Destroy session after exiting watch goroutine
- Return error if acting on destroyed session
